### PR TITLE
Fixed #4. Error when using the get function.

### DIFF
--- a/lib/sftp-wrapper.js
+++ b/lib/sftp-wrapper.js
@@ -95,7 +95,7 @@ SFTPWrapper.prototype.get = function (path, useCompression, cb) {
 	stream.on('error', handleError);
 
 	stream.on('open', function (handle) {
-		stream.removeListener(handleError);
+		stream.removeListener('error', handleError);
 
 		return cb(null, stream);
 	});


### PR DESCRIPTION
Looks like wrong `removeListener` invocation in the sftp-wrapper.

Fixed.
